### PR TITLE
#156 - Fix for console error + non-loaded comment editor using touchbased devices in pin mode

### DIFF
--- a/shared/index.js
+++ b/shared/index.js
@@ -8135,20 +8135,24 @@ function startIndex(
                                     documentId = _getMetadata.documentId;
                                     pageNumber = _getMetadata.pageNumber;
                                     deleteUndefinedPin();
-                                    var coordinates = {
-                                        x: e.changedTouches[0].clientX,
-                                        y: e.changedTouches[0].clientY,
-                                    };
-                                    renderPinTouchscreen(coordinates);
-                                    [textarea, data] = (0, _commentWrapper.openCommentTouchscreen)(
-                                        e,
-                                        handleCancelClick,
-                                        handleSubmitClick,
-                                        handleToolbarClick,
-                                        handleSubmitBlur,
-                                        'pin'
-                                    );
+                                    var fn = () => {
+                                        [textarea, data] = (0, _commentWrapper.openCommentTouchscreen)(
+                                            e,
+                                            handleCancelClick,
+                                            handleSubmitClick,
+                                            handleToolbarClick,
+                                            handleSubmitBlur,
+                                            'pin'
+                                        );
+                                        var coordinates = {
+                                            x: e.changedTouches[0].clientX,
+                                            y: e.changedTouches[0].clientY,
+                                        };
+                                        renderPinTouchscreen(coordinates);
+                                    }
+                                    _commentWrapper.loadEditor('add', 0, fn);
                                 }
+
 
                                 /**
                                  * If the toolbar is clicked, the point tool should be disabled and the commentswrapper should be closed


### PR DESCRIPTION
This fixes the console error from #156 by preloading the comment editor when adding a pin via touch.

Fixing this also brings the add comment textarea in focus (meaning into the viewpoint) in touch mode so that one can directly enter the comment.