### PR TITLE
#157 - Fix for console errors + non-loaded comment editor using touchbased devices in rectangle mode

### DIFF
--- a/shared/index.js
+++ b/shared/index.js
@@ -8691,27 +8691,30 @@ function startIndex(
                                                 return;
                                             }
                                             var _svg = overlay.parentNode.querySelector('svg.annotationLayer');
-                                            renderRect(
-                                                _type,
-                                                [
-                                                    {
-                                                        top: parseInt(overlay.style.top, 10) + rect.top,
-                                                        left: parseInt(overlay.style.left, 10) + rect.left,
-                                                        width: parseInt(overlay.style.width, 10),
-                                                        height: parseInt(overlay.style.height, 10),
-                                                    },
-                                                ],
-                                                null
-                                            );
+                                            var fn = () => {
+                                                [textarea, data] = (0, _commentWrapper.openCommentTouchscreen)(
+                                                    e,
+                                                    handleCancelTouch,
+                                                    handleSubmitClick,
+                                                    handleToolbarClick,
+                                                    handleSubmitBlur,
+                                                    _type
+                                                );
+                                                renderRect(
+                                                    _type,
+                                                    [
+                                                        {
+                                                            top: parseInt(overlay.style.top, 10) + rect.top,
+                                                            left: parseInt(overlay.style.left, 10) + rect.left,
+                                                            width: parseInt(overlay.style.width, 10),
+                                                            height: parseInt(overlay.style.height, 10),
+                                                        },
+                                                    ],
+                                                    null
+                                                );
+                                            }
+                                            _commentWrapper.loadEditor('add', 0, fn);
 
-                                            [textarea, data] = (0, _commentWrapper.openComment)(
-                                                e,
-                                                handleCancelTouch,
-                                                handleSubmitClick,
-                                                handleToolbarClick,
-                                                handleSubmitBlur,
-                                                _type
-                                            );
                                         } else if ((rectsSelection = getSelectionRects()) && _type !== 'area') {
                                             renderRect(
                                                 _type,


### PR DESCRIPTION
This fixes #157. The comment editor is preloaded, so the following errors just don't happen, it seems. Before the fix when one selected "select mode" the old rectangle without any attached comments stayed, with the fix a comment-less rectangle is removed.

This probably helps preventing the other errors.

You should probably (easy to say, I know) move to another modern PDF annotation library...? ;-)